### PR TITLE
48 get ansible scripts working with the noisy atom web site

### DIFF
--- a/noisyatom_webportal/README.md
+++ b/noisyatom_webportal/README.md
@@ -1,11 +1,46 @@
 # Using Ansible To Deploy And Setup Noisy Atom Web Portal
-This describes the installation and setup of Noisy Atom web server. It requires that you have ansible setup on your
-host, the ansible vault password and a remote machine that you have access to as the root user. 
+This describes the installation and setup of Noisy Atom web server. It requires that you have ansible and ansible vault
+setup on your host. The ansible vault file embedded in this project will require a  password and a remote machine to
+deploy to that you have access to as the root user. 
 
+Tha ansible vault file is: **/vars/protected_vars.yml**
+
+If you know how to use ansible vault and happy using the file provided, you can skip to the next section.
+
+### Ansible Vault Cheat Sheet
+Ansible vault encrypts sensitive data for your system. Currently sensitive data is contained within the file:
+	**protected_vars.yml** file.
+This file contains passwords for:
+1. cms user
+2. admin user
+3. database password
+4. database user name
+5. database name
+6. django admin
+7. default django user
+
+They can be viewed, edited or deleted by you provided you know the vault password. 
+Commands to view the file:
+
+```
+	/> ansible-vault view protected_vars.yml
+```
+
+Commands to edit the file:
+```
+	/> ansible-vault edit protected_vars.yml
+```
+
+Commands to encrypt a new file:
+```
+	/> ansible-vault encrypt protected_vars.yml
+```
+
+The following steps explain step by step on how to run the ansible scripts to set up a vanilla server.
 
 ## 1. Customise Your Host File
-The first thing to customize is the hosts file. This is the file where you could list all the hosts controlled by Ansible. 
-If you only want to deploy to one machine only put one entry in this.
+The first thing to customize is the hosts file. This is the file where you could list all the hosts controlled by 
+Ansible. If you only want to deploy to one machine only put one entry in this.
 
 	/> nano hosts
 	
@@ -36,7 +71,9 @@ Check your key is installed by trying to SSH to the machine:
 
 
 ## 3. Brief Description Of Files
-Here is a brief description of each playbook you’ll find:
+Here is a brief description of each playbook. A playbook is a list of instructions carried out by ansible. Ansible will
+run a playbook to carry out the tasks described on your remote machine. Here you’ll find a description of each
+playbook:
 
 ### 3.2 create_users.yml
 This creates an admin and CMS user on the remote server. When setting up server components and installing software the admin user will be used. When running the web portal and setting the portal up only the CMS user will be used.
@@ -63,16 +100,25 @@ gunicorn files.
 Connects in as admin user. Allows root access via SSH. Connects as root and and removes admin and CMS users.
 
 
-## 4. Setup Users On Your Machine
-------------------------------
-As the root user, setup an admin user and a CMS user. The admin user will have sudo access to the machine. The CMS 
-user will have limited access to the machine. The admin and CMS user names are defined in the /vars/project_variables.yml file.
+## 4. Setup Users On Your Machine With *create_users.yml
+--------------------------------------------------------
+This script will connect as root user, and setup an admin user and a CMS user. The admin user will have sudo access 
+to the machine. The CMS user will have limited access to the machine. The admin and CMS username passwords are 
+defined in:
+	**/vars/project_variables.yml** file.
+
+To manually login to the server you will need to use the admin or CMS username which are:
+* noisy_atom_admin
+* noisy_atom_cms
+
+e.g. `/> ssh noisy_atom_admin@10.10.10.10`
+
 * Note: Once you run this script root will not be able to login directly via SSH.
 
 ### 4.1 Setup Host Variable If Needed
-The create_users.yml file has a hosts variable at the top of the script. Ensure that the host you want to run the script against 
-is configured here  and matches what you have in the 'host' file. At the time of writing it was tested against NoisyAtomUbuntu14 
-machine. e.g.
+The create_users.yml file has a hosts variable at the top of the script. Ensure that the host you want to run the script 
+against is configured here  and matches what you have in the 'host' file. At the time of writing it was tested against 
+NoisyAtomUbuntu14 machine. e.g.
 ```
 	- hosts: NoisyAtomUbuntu14
 ```
@@ -86,15 +132,15 @@ From the root folder of this readme file do:
 
 ## 5. Install Software On Your Machine
 -----------------------------------
-As the admin user, this installs all the required base packages needed on your machine. Pip, Django, Nginx, Postgres and so on. 
-It configures the DB, DB name and the DB user. It creates a virtual environment and installs django and python to the virtual 
-env. It starts Postgres and Nginx. It finally stops Nginx and root access via SSH.
+As the admin user, this installs all the required base packages needed on your machine. Pip, Django, Nginx, Postgres 
+and so on. It configures the DB, DB name and the DB user. It creates a virtual environment and installs django and 
+python to the virtual env. It starts Postgres and Nginx. It finally stops Nginx and root access via SSH.
 
 ### 5.1 Setup Host Variable If Needed
-The install_software.yml file has a hosts variable at the top of the script, and near the end. Ensure that the host you want to 
-run the script against is configured here  and matches what you have in the 'host' file. At the time of writing it was tested against 
-NoisyAtomUbuntu14 machine. e.g.
-	- hosts: NoisyAtomUbuntu14
+The install_software.yml file has a hosts variable at the top of the script, and near the end. Ensure that the host 
+you want to run the script against is configured here  and matches what you have in the 'host' file. At the time of 
+writing it was tested against NoisyAtomUbuntu14 machine. e.g.
+	- hosts: NoisyAtomUbuntu18
 
 ### 5.2 Running The File
 From the root folder of this readme file do:

--- a/noisyatom_webportal/config/gunicorn.service
+++ b/noisyatom_webportal/config/gunicorn.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=gunicorn daemon
+Requires=gunicorn.socket
+After=network.target
+
+[Service]
+User=noisy_atom_cms
+Group=www-data
+WorkingDirectory=/home/noisy_atom_cms/NoisyAtomPortal/noisyatom
+ExecStart=/home/noisy_atom_cms/noisy_atom_venv/bin/gunicorn \
+          --access-logfile - \
+          --workers 3 \
+          --bind unix:/run/gunicorn.sock config.wsgi:application
+
+[Install]
+WantedBy=multi-user.target

--- a/noisyatom_webportal/config/gunicorn.socket
+++ b/noisyatom_webportal/config/gunicorn.socket
@@ -1,0 +1,8 @@
+[Unit]
+Description=gunicorn socket
+
+[Socket]
+ListenStream=/run/gunicorn.sock
+
+[Install]
+WantedBy=sockets.target

--- a/noisyatom_webportal/config/noisyatom
+++ b/noisyatom_webportal/config/noisyatom
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name 167.99.92.82;
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location /static-cdn/ {
+        root /home/noisy_atom_cms/NoisyAtomPortal/;
+    }
+
+    location / {
+        include proxy_params;
+        proxy_pass http://unix:/run/gunicorn.sock;
+    }
+
+}

--- a/noisyatom_webportal/create_users.yml
+++ b/noisyatom_webportal/create_users.yml
@@ -1,10 +1,10 @@
-# This file will connect to a remote server called NoisyAtomUbuntu14 (taken from your hosts file) and  will add users
+# This file will connect to a remote server called NoisyAtomUbuntu18 (taken from your hosts file) and  will add users
 # 'noisy_atom_admin' and 'noisy_atom_cms', their passwords and directory structures. It then adds your public key on your 
 # host computer and copy for those users to the remote computer. The adminuser is added to the list of sudoers. It then setups 
 # up the bashrc script for your users and has a task to setup the SSH server to stop root access. This part is not active at 
 # the time of writing.
 
-# **** Prerequisits ****
+# **** Prerequisites ****
 # 1) You need to have a root user setup on your remote server
 # 2) The SSH private key on your local machine must be copied to the root user account on the 
 #	 remote machine. e.g. />  ssh-copy-id root@104.236.14.12
@@ -17,7 +17,7 @@
 
 
 ---
-- hosts: NoisyAtomUbuntu14
+- hosts: NoisyAtomUbuntu18
 #- hosts: ub14-test
   user: root
 

--- a/noisyatom_webportal/deploy_server.yml
+++ b/noisyatom_webportal/deploy_server.yml
@@ -8,8 +8,8 @@
 # run collectstatic,
 # restart nginx and gunicorn
 
-# **** Prerequisits ****
-# 1) You need to have run install_software.yml and performed it's prerequisits.
+# **** Prerequisites ****
+# 1) You need to have run install_software.yml and performed it's prerequisites.
 # 2) You need to know the password of the 'protected_vars.yml' file which is used to provide encrypted
 #	 data for password variables in the script.
 
@@ -18,7 +18,7 @@
 
 
 ---
-- hosts: NoisyAtomUbuntu14
+- hosts: NoisyAtomUbuntu18
 #- hosts: ub14-test
   user: '{{cmsuser}}'
 
@@ -97,7 +97,7 @@
 
 
 # Now connect to the remote machine as the admin user since we want to setup nginx and gunicorn
-- hosts: NoisyAtomUbuntu14
+- hosts: NoisyAtomUbuntu18
 #- hosts: ub14-test
   user: '{{adminuser}}'
   become: true                                                 # This will tell ansible to become 'sudo' to issue commands on the machine
@@ -124,6 +124,8 @@
       with_items:
         - { file_name: 'config/gunicorn.conf', destination_directory: '/etc/init' }
         - { file_name: 'config/naecommerce', destination_directory: '/etc/nginx/sites-available' }
+      environment:
+        ENVIRONMENT: prod
 
     ## Map the configuration files directory in Nginx to the enabled directory.
     ## This has the effect of enabling the URL's mapped in the config file.

--- a/noisyatom_webportal/deploy_server.yml
+++ b/noisyatom_webportal/deploy_server.yml
@@ -102,6 +102,12 @@
   user: '{{adminuser}}'
   become: true                                                 # This will tell ansible to become 'sudo' to issue commands on the machine
 
+  environment:
+    ENVIRONMENT: "prod"
+    NOISY_ATOM_DB_PASSWORD: '{{dbpassword}}'
+    NOISY_ATOM_DB_USER: '{{dbuser}}'
+    NOISY_ATOM_DB: '{{dbname}}'
+
   vars_files:
   - vars/project_variables.yml
 #  - vars/unprotected_vars.yml                                # Used for testing with unencrypted password file i.e. no vault
@@ -114,28 +120,27 @@
     - name: Reload Nginx to enable the site
       service: name=nginx state=restart enabled=yes
 
-    - name: Reload Gunicorn WSGI Server
-      service: name=gunicorn state=reloaded enabled=yes
+    - name: Restart Gunicorn WSGI Server
+      service: name=gunicorn state=restarted enabled=yes
 
   tasks:
     ## Configure our gunicorn wsgi server. We need to copy our gunicorn.conf file across to the server.
-    - name: Copy 'gunicorn.con' And 'naecommerce' Nginx Config To Our Server
+    - name: Copy 'gunicorn.socket', 'gunicorn.service' Gunicorn config And 'noisyatom' Nginx Config To Our Server
       copy: src={{item.file_name}} dest={{item.destination_directory}} owner=root group=root mode="u=r,g=r,o=rw"
       with_items:
-        - { file_name: 'config/gunicorn.conf', destination_directory: '/etc/init' }
-        - { file_name: 'config/naecommerce', destination_directory: '/etc/nginx/sites-available' }
-      environment:
-        ENVIRONMENT: prod
+        - { file_name: 'config/{{gunicorn_socket_file}}', destination_directory: '/etc/systemd/system' }
+        - { file_name: 'config/{{gunicorn_service_file}}', destination_directory: '/etc/systemd/system' }
+        - { file_name: 'config/{{nginx_config}}', destination_directory: '/etc/nginx/sites-available' }
 
     ## Map the configuration files directory in Nginx to the enabled directory.
     ## This has the effect of enabling the URL's mapped in the config file.
-    - name: Link naecomerce Nginx config file in sites-available to sites-enabled
-      file: src=/etc/nginx/sites-available/naecommerce dest=/etc/nginx/sites-enabled/naecommerce state=link
+    - name: Link NoisyAtom Nginx config file in sites-available to sites-enabled
+      file: src=/etc/nginx/sites-available/{{nginx_config}} dest=/etc/nginx/sites-enabled/{{nginx_config}} state=link
       notify: Reload Nginx to enable the site
-      notify: Reload Gunicorn WSGI Server
+      notify: Restart Gunicorn WSGI Server
 
     - name: Reload Nginx to enable the site
       service: name=nginx state=restarted enabled=yes
 
-    - name: Reload Gunicorn WSGI Server
-      service: name=gunicorn state=reloaded enabled=yes
+    - name: Restart Gunicorn WSGI Server
+      service: name=gunicorn state=restarted enabled=yes

--- a/noisyatom_webportal/hosts
+++ b/noisyatom_webportal/hosts
@@ -2,7 +2,6 @@
 # ************** Setup all host and IP names for servers *****************
 # ************************************************************************
 
-
 # Example server
 #[example]
 #188.166.145.32
@@ -22,50 +21,24 @@
 
 
 # ************************************************************************
-# *****************     Setup all Dilshads Resume      *******************
-[Dilshad-Resume]
-139.59.164.130
-
-
-
-# ************************************************************************
-# ***********  Setup Ubuntu 14.5 Test Server Digital Oceans **************
-
-# Ubuntu 14 Test Server On Digital Oceans
-# This machine is setup from Nicholas Herriot's account and running Ubuntu 14.5 LTR
-#[ubuntu14-test]
-#46.101.8.117
-
-
-# ************************************************************************
 # ********  Setup Ubuntu 16.1 Noisy Atom Portal Digital Oceans ***********
 
-
-[NoisyAtomUbuntu14]
+# Ubuntu 16 Noisy Atom Server On Digital Oceans
+# This machine is setup from Nicholas Herriot's account and running Ubuntu 16.1 LTR
+[NoisyAtomUbuntu16]
 104.236.14.123
 
-[ub14-test]
-46.101.19.29
-
-#[NoisyAtom-Portal:vars] # Ubuntu 16.04 hosts without python2
-#ansible_python_interpreter=/usr/bin/python2.7
-
 
 # ************************************************************************
-# ****************** Setup all groups for each server ********************
+# ****** Setup Ubuntu 18.4 Noisy Atom Porte on Digital Oceans ************
 # ************************************************************************
 
+# Ubuntu 18 Noisy Atom Server On Digital Oceans
+# This machine is setup from Nicholas Herriot's account and running Ubuntu 18.4 LTR
+[NoisyAtomUbuntu18]
+134.209.21.58
+
+[NoisyAtomUbuntu18:vars]
+ansible_python_interpreter=/usr/bin/python3
 
 
-# ************************************************************************
-# **************** Setup all variables for each server *******************
-# ************************************************************************
-
-#[ubuntu14-test:vars]
-#ansible_ssh_user=root
-
-#[NoisyAtom-Portal]
-#ansible_ssh_user=root
-
-#[Dilshad-Resume]
-#ansible_ssh_user=root

--- a/noisyatom_webportal/hosts
+++ b/noisyatom_webportal/hosts
@@ -36,7 +36,7 @@
 # Ubuntu 18 Noisy Atom Server On Digital Oceans
 # This machine is setup from Nicholas Herriot's account and running Ubuntu 18.4 LTR
 [NoisyAtomUbuntu18]
-134.209.21.58
+167.99.92.82
 
 [NoisyAtomUbuntu18:vars]
 ansible_python_interpreter=/usr/bin/python3

--- a/noisyatom_webportal/install_software.yml
+++ b/noisyatom_webportal/install_software.yml
@@ -35,7 +35,7 @@
     - name: Running update
       apt:
         update_cache=yes
-        cache_valid_time=3600
+        cache_valid_time=30
       register: result
 
     - name: Output From Running Update
@@ -50,7 +50,7 @@
     - name: Installing required packages ( python-pip, python-dev, libpq-dev, postgresql, postgresql-contrib psycopg2 and nginx )
       apt: name={{item}} state=present
       with_items:
-       - {{python_version}}
+       - '{{python_version}}'
        - python3-pip
        - python3-dev
        - postgresql

--- a/noisyatom_webportal/install_software.yml
+++ b/noisyatom_webportal/install_software.yml
@@ -18,7 +18,7 @@
 
 
 ---
-- hosts: NoisyAtomUbuntu14
+- hosts: NoisyAtomUbuntu18
 #- hosts: ub14-test
   user: '{{adminuser}}'
   become: true                                                # This will tell ansible to become 'sudo' to issue commands on the machine
@@ -50,14 +50,14 @@
     - name: Installing required packages ( python-pip, python-dev, libpq-dev, postgresql, postgresql-contrib psycopg2 and nginx )
       apt: name={{item}} state=present
       with_items:
-       - python-pip
-       - python-dev
+       - {{python_version}}
+       - python3-pip
+       - python3-dev
        - postgresql
        - postgresql-client
        - git
-       - python-pip
        - libpq-dev
-       - python-psycopg2
+       - python3-psycopg2
        - nginx
 
     ## Start the nginx server.
@@ -73,7 +73,7 @@
     - name: Ensure user has access to database
       become: yes
       become_user: postgres
-      postgresql_user: db={{dbname}} name={{dbuser}} password={{dbpassword}} priv=ALL
+      postgresql_user: db={{dbname}} name={{dbuser}} password={{dbpassword}} encrypted=yes priv=ALL
 
     - name: Ensure user does not have unnecessary privilege
       become: yes
@@ -81,7 +81,7 @@
       postgresql_user: name={{dbuser}} role_attr_flags=NOSUPERUSER,NOCREATEDB
 
 
-- hosts: NoisyAtomUbuntu14
+- hosts: NoisyAtomUbuntu18
 #- hosts: ub14-test
   user: '{{cmsuser}}'
 

--- a/noisyatom_webportal/upgrade_new_release.yml
+++ b/noisyatom_webportal/upgrade_new_release.yml
@@ -6,8 +6,8 @@
 # restarts gunicorn,
 # restarts nginx.
 
-# **** Prerequisits ****
-# 1) You need to have run deploy_server.yml and performed it's prerequisits.
+# **** Prerequisites ****
+# 1) You need to have run deploy_server.yml and performed it's prerequisites.
 # 2) You need to know the password of the 'protected_vars.yml' file which is used to provide encrypted
 #	 data for password variables in the script.
 
@@ -16,7 +16,7 @@
 
 
 ---
-- hosts: NoisyAtomUbuntu14
+- hosts: NoisyAtomUbuntu18
 #- hosts: ub14-test
   user: '{{cmsuser}}'
 
@@ -73,7 +73,7 @@
 
 
 # Now connect to the remote machine as the admin user since we want to setup nginx and gunicorn
-- hosts: NoisyAtomUbuntu14
+- hosts: NoisyAtomUbuntu18
 #- hosts: ub14-test
   user: '{{adminuser}}'
   become: true                                                 # This will tell ansible to become 'sudo' to issue commands on the machine

--- a/noisyatom_webportal/vars/project_variables.yml
+++ b/noisyatom_webportal/vars/project_variables.yml
@@ -17,9 +17,13 @@ project_root: ~/NoisyAtomPortal                           # this is the root fol
 project_name: noisyatom                                   # this is the name of our project
 project_repo: https://github.com/nherriot/noisy-atom-portal.git
 django_settings: config.settings                          # this is where we get our settings.py from
-#git_branch: production                                    # this is the branch we pull from for our production system
-git_branch: master
-
+gunicorn_service_file: gunicorn.service                   # this is the name of the file to setup a systemd service for gunicorn
+gunicorn_socket_file: gunicorn.socket                     # this is the name of the file to setup a systemd socket for gunicorn
+nginx_config: noisyatom                                   # this is the name of the file to setup a systemd service for nginx
+#git_branch: production                                   # this is the branch we pull from for our production system
+#git_branch: master
+# temp git-branch to allow testing of new scripts. DO NOT COMMIT THIS TO MASTER BRANCH!
+git_branch: 48-get-ansible-scripts-working-with-the-noisy-atom-web-site
 # software version
 python_version: python3.8
 django_version: 2

--- a/noisyatom_webportal/vars/project_variables.yml
+++ b/noisyatom_webportal/vars/project_variables.yml
@@ -21,9 +21,7 @@ gunicorn_service_file: gunicorn.service                   # this is the name of 
 gunicorn_socket_file: gunicorn.socket                     # this is the name of the file to setup a systemd socket for gunicorn
 nginx_config: noisyatom                                   # this is the name of the file to setup a systemd service for nginx
 #git_branch: production                                   # this is the branch we pull from for our production system
-#git_branch: master
-# temp git-branch to allow testing of new scripts. DO NOT COMMIT THIS TO MASTER BRANCH!
-git_branch: 48-get-ansible-scripts-working-with-the-noisy-atom-web-site
+git_branch: master
 # software version
 python_version: python3.8
 django_version: 2

--- a/noisyatom_webportal/vars/project_variables.yml
+++ b/noisyatom_webportal/vars/project_variables.yml
@@ -18,8 +18,8 @@ project_name: noisyatom                                   # this is the name of 
 project_repo: https://github.com/nherriot/noisy-atom-portal.git
 django_settings: config.settings                          # this is where we get our settings.py from
 #git_branch: production                                    # this is the branch we pull from for our production system
-git_branch: ISU003_Deployed_Production_Server_Cant_Connect_To_DB   # temporary added for testing.
+git_branch: master
 
 # software version
-python_version: python3.5
-django_version: 1.9.2
+python_version: python3.8
+django_version: 2


### PR DESCRIPTION
This fixes issue within the NoisyAtom portal application here: https://github.com/nherriot/noisy-atom-portal/issues/48

To test this pull request follow the documents here:
* SETUP_ANSIBLE.md
* TEST_ANSIBLE.md
* README.md

After this you will need to create a droplet on digital oceans to test with. Once you have a droplet follow the steps below:
1. create root account onto your digital oceans droplet running Ubuntu18.0 (this should be supplied when you start).
2. copy your SSL public key to your new droplet and ensure you can ssh via root. (e.g. /> ssh root@<your_new_ip_address>)
3. now go to your root folder with your ansible scripts. Open the hosts file and update the following section with the IP address of your new droplet. e.g.

```
# ************************************************************************
# ****** Setup Ubuntu 18.4 Noisy Atom Porte on Digital Oceans ************
# ************************************************************************

# Ubuntu 18 Noisy Atom Server On Digital Oceans
# This machine is setup from Nicholas Herriot's account and running Ubuntu 18.4 LTR
[NoisyAtomUbuntu18]
167.99.92.82
```
Update your IP address in the hosts file within the /noisyatom_webporta directory.

4. Navigate to the /config directory and update the file: **noisyatom** with your IP address in the section shown below:

```
server {
    listen 80;
    server_name 167.99.92.82;
```

5. Contact N.Herriot to use his ansible vault script if you wish, or you can create your own (ask N.Herriot how do do this)
6. Run the first ansible scirpt:

```
   />  ansible-playbook create_users.yml --ask-vault-pass
```

7. Run the 2nd ansible script to install software:

```
   />  ansible-playbook install_software.yml --ask-vault-pass
```

8. Run the 3rd ansible script to deploy the web server.

```
   />  ansible-playbook deploy_server.yml --ask-vault-pass
```

9. Go to your IP address on your browser. You should see the deployed system.


![noisyatom-new](https://user-images.githubusercontent.com/249986/173587864-6c400db3-09ef-4667-b02f-15c4f20c6af2.png)


**Note:** You will no longer be able to login with your root account. This will be disabled. You will need to login with the following accounts:

**noisy_atom_cms**
**noisy_atom_admin**

