### PR TITLE
25 update system to use noisyatom com site

### DIFF
--- a/noisyatom_webportal/config/README.md
+++ b/noisyatom_webportal/config/README.md
@@ -1,0 +1,38 @@
+# Configuration Docuements
+This contains descriptions of configuration documents, what they do and how to use them for the project.
+
+
+
+## Gunicorn Documents
+The web portal uses NGINX as a HTTP/WEB proxy. It provides separation and SSL certification to the portal. It protects
+against attacks like denial of service. From there it routes onto Gunicorn which provides a process engine to allow
+multiple django instances to be spun up for multiple users.
+
+For Ubuntu 14 there is only one configuration file called **gunicorn.conf**. It should be deployed with Ubuntu 14 onlu
+and will not work with Ubuntu 18 and above.
+
+For Ubuntu 18.04 the web portal needs to deploy **gunicorn.socket** and gunicorn.service. Since Linux now uses **systemd**
+we need to deploy Gunicorn as a service which is launched by systemd when there are IP packets arriving on the defined
+Linux socket. Systemd will run a socket daemon for Gunicorn. Then it will automatically launch the **gunicorn.service**
+file, which launches instances of the Django web platform.
+
+
+
+## NAECOMMERCE
+The naecommerce documents are configuration files used to deploy into NGINX /etc/nginx/sites-available directory.
+This is used to configure what NGINX will proxy too. What sections are static content (e.g. images). How NGINX will
+proxy to Gunicorn. What PEM files are used for SSL certification.
+
+There is an naecommerce-template document which simply shows how a template could be build for other projects.
+
+Both documents are used to launch the old NoisyAtom.tech site which was based on Ubuntu 14.04. Those files will not
+work on anything above Ubuntu 18.
+
+
+
+## NOISYATOM
+The noisyatom documents are configuration files used to deploy into NGINX /etc/nginx/sites-available directory.
+This is used to configure what NGINX will proxy too. What sections are static content (e.g. images). How NGINX will
+proxy to Gunicorn. What PEM files are used for SSL certification.
+
+This document is used to deploy onto NGINX running on Ubuntu 18.04. It has been tested on Ubuntu 20+ at it works.

--- a/noisyatom_webportal/config/naecommerce
+++ b/noisyatom_webportal/config/naecommerce
@@ -1,7 +1,5 @@
-
 server {
-    listen 80;
-    server_name 104.236.14.123;
+    server_name 104.236.14.123 www.noisyatom.tech noisyatom.tech noisyatom.com www.noisyatom.com ;
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location /static-cdn/ {
@@ -12,5 +10,12 @@ server {
         include proxy_params;
         proxy_pass http://unix:/home/noisy_atom_cms/NoisyAtomPortal/noisyatom/naproject.sock;
     }
+
+
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/noisyatom.tech/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/noisyatom.tech/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 
 }


### PR DESCRIPTION
This closes issue: https://github.com/nherriot/noisy-atom-portal/issues/25

You can test this out by going to noisyatom.com.

The site will not have the correct SSL certificate. But I will not update this until we deploy onto Ubutu 18.04. This issues is just to ensure that we correctly serve up pages for noisyatom.com.

![noisyatom com](https://user-images.githubusercontent.com/249986/175261006-b951da89-d170-4dc9-ab47-904958b6ff95.png)

The pull request is to a different github repo as only configuration files were updated. There is also a README file explaining what the new files are for. There are no code changes to review as such.


